### PR TITLE
Fix for Debian Buster

### DIFF
--- a/files/version.sh
+++ b/files/version.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-
+  
 set -e
 
 PUPPET_GOGS_INSTALLATION_DIRECTORY=$1
@@ -11,17 +11,10 @@ if [ ${PUPPET_GOGS_VERSION} == "latest" ]; then
     PUPPET_GOGS_VERSION=${LATEST_VERSION}
 fi
 
-DOWNLOAD_VERSION_URL="https://raw.githubusercontent.com/gogits/gogs/v${PUPPET_GOGS_VERSION}/templates/.VERSION"
+LOCAL_VERSION=$(${PUPPET_GOGS_INSTALLATION_DIRECTORY}/gogs --version 2>/dev/null| awk '{print $3}')
 
-if [ -f "${PUPPET_GOGS_INSTALLATION_DIRECTORY}/templates/.VERSION" ]; then
-
-    LOCAL_VERSION=$(<"${PUPPET_GOGS_INSTALLATION_DIRECTORY}/templates/.VERSION")
-    REMOTE_VERSION=$(wget -O- -q ${DOWNLOAD_VERSION_URL}) || exit 0
-
-    if [ ${LOCAL_VERSION} == ${REMOTE_VERSION} ]; then
-        exit 1
-    fi
-    exit 0
+if [ ${LOCAL_VERSION} == ${PUPPET_GOGS_VERSION} ]; then
+  exit 1
+else
+  exit 0
 fi
-
-exit 0

--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -15,7 +15,7 @@ class gogs::packages (
         ensure_packages(['git', 'curl', 'wget', 'tar', 'initscripts'])
       }
       'Debian': {
-        ensure_packages(['git-core', 'curl', 'wget', 'tar'])
+        ensure_packages(['git', 'curl', 'wget', 'tar'])
       }
       'Ubuntu': {
         ensure_packages(['git-core', 'curl', 'wget', 'tar'])

--- a/manifests/sysconfig/debian.pp
+++ b/manifests/sysconfig/debian.pp
@@ -4,6 +4,7 @@ define gogs::sysconfig::debian (
   $installation_directory = $gogs::installation_directory,
   $owner                  = $gogs::owner,
   $group                  = $gogs::group,
+  $home                   = $gogs::home,
 
 ) {
 
@@ -52,7 +53,7 @@ define gogs::sysconfig::debian (
   file_line { '${service_name}.service Environment':
     ensure => present,
     path   => "/etc/systemd/system/${service_name}.service",
-    line   => "Environment=USER=${owner} HOME=${installation_directory}",
+    line   => "Environment=USER=${owner} HOME=${home}",
     match  => "^Environment=",
     notify => Exec['/bin/systemctl daemon-reload'],
   }

--- a/manifests/sysconfig/debian.pp
+++ b/manifests/sysconfig/debian.pp
@@ -12,7 +12,7 @@ define gogs::sysconfig::debian (
     source => "${installation_directory}/scripts/systemd/gogs.service",
     owner  => 'root',
     group  => 'root',
-    mode   => '0755',
+    mode   => '0644',
     replace => false,
     notify => Service[$service_name],
   }  ~>

--- a/manifests/sysconfig/debian.pp
+++ b/manifests/sysconfig/debian.pp
@@ -3,34 +3,57 @@ define gogs::sysconfig::debian (
   $service_name           = $gogs::service_name,
   $installation_directory = $gogs::installation_directory,
   $owner                  = $gogs::owner,
+  $group                  = $gogs::group,
 
 ) {
 
-  # @see https://github.com/gogits/gogs/blob/master/scripts/init/centos/gogs
-  $sysconfig = {
-    'NAME'       => $service_name,
-    'USER'       => $owner,
-    'WORKINGDIR' => $installation_directory,
-    'DAEMON'     => "${installation_directory}/${service_name}",
-  }
-
-  file { "/etc/default/${service_name}":
-    ensure  => 'file',
-    content => template('gogs/sysconfig.erb'),
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0755',
-    notify  => Service[$service_name],
-    before  => File["/etc/init.d/${service_name}"],
-  }
-
-  file { "/etc/init.d/${service_name}":
+  file { "/etc/systemd/system/${service_name}.service":
     ensure => file,
-    source => "${installation_directory}/scripts/init/debian/gogs",
+    source => "${installation_directory}/scripts/systemd/gogs.service",
     owner  => 'root',
     group  => 'root',
     mode   => '0755',
+    replace => false,
+    notify => Service[$service_name],
+  }  ~>
+  exec { '/bin/systemctl daemon-reload':
+    refreshonly => true,
     notify => Service[$service_name],
   }
 
+  file_line { '${service_name}.service User':
+    ensure => present,
+    path   => "/etc/systemd/system/${service_name}.service",
+    line   => "User=${owner}",
+    match  => "^User=",
+    notify => Exec['/bin/systemctl daemon-reload'],
+  }
+  file_line { '${service_name}.service Group':
+    ensure => present,
+    path   => "/etc/systemd/system/${service_name}.service",
+    line   => "Group=${group}",
+    match  => "^Group=",
+    notify => Exec['/bin/systemctl daemon-reload'],
+  }
+  file_line { '${service_name}.service WorkingDirectory':
+    ensure => present,
+    path   => "/etc/systemd/system/${service_name}.service",
+    line   => "WorkingDirectory=${installation_directory}",
+    match  => "^WorkingDirectory=",
+    notify => Exec['/bin/systemctl daemon-reload'],
+  }
+  file_line { '${service_name}.service ExecStart':
+    ensure => present,
+    path   => "/etc/systemd/system/${service_name}.service",
+    line   => "ExecStart=${installation_directory}/gogs web",
+    match  => "^ExecStart=",
+    notify => Exec['/bin/systemctl daemon-reload'],
+  }
+  file_line { '${service_name}.service Environment':
+    ensure => present,
+    path   => "/etc/systemd/system/${service_name}.service",
+    line   => "Environment=USER=${owner} HOME=${installation_directory}",
+    match  => "^Environment=",
+    notify => Exec['/bin/systemctl daemon-reload'],
+  }
 }


### PR DESCRIPTION
The current version "mod 'kschu91-gogs', '1.5.0'" doesn't work on Debian 10 (buster) anymore.
I fixed the mistakes ...